### PR TITLE
make -main-tu-only CodeStyleChecker behavior consistent with comments

### DIFF
--- a/lib/CodeStyleChecker.cpp
+++ b/lib/CodeStyleChecker.cpp
@@ -17,7 +17,7 @@
 //    LLVM's coding guidelines.
 //
 //    By default this plugin will only run on the main translation unit. Use
-//    `-main-tu-only=true` to make it run on e.g. included header files too.
+//    `-main-tu-only=false` to make it run on e.g. included header files too.
 //
 // USAGE:
 //    Main TU only:
@@ -25,7 +25,7 @@
 //        input-file.cpp
 //    All TUs (the main file and the #includ-ed header files)
 //      * clang -cc1 -load libCodeStyleChecker.dylib -plugin CSC `\`
-//        -main-tu-only=true input-file.cpp
+//        -plugin-arg-CSC -main-tu-only=false input-file.cpp
 //
 // License: The Unlicense
 //==============================================================================
@@ -172,7 +172,7 @@ public:
   bool ParseArgs(const CompilerInstance &CI,
                  const std::vector<std::string> &Args) override {
     for (StringRef Arg : Args) {
-      if (Arg.startswith("-"))
+      if (Arg.startswith("-main-tu-only="))
         MainTuOnly = Arg.substr(strlen("-main-tu-only=")).equals_lower("true");
       else if (Arg.startswith("-help"))
         PrintHelp(llvm::errs());
@@ -188,7 +188,7 @@ public:
   }
 
 private:
-  bool MainTuOnly = false;
+  bool MainTuOnly = true;
 };
 
 //-----------------------------------------------------------------------------

--- a/tools/CodeStyleCheckerMain.cpp
+++ b/tools/CodeStyleCheckerMain.cpp
@@ -10,7 +10,7 @@
 //  Main TU only:
 //    * ct-code-style-checker input-file.cpp
 //  All TUs (the main file and the #includ-ed header files)
-//    * ct-code-style-checker -main-tu-only=true input-file.cpp
+//    * ct-code-style-checker -main-tu-only=false input-file.cpp
 //
 // License: The Unlicense
 //==============================================================================
@@ -31,7 +31,7 @@ static llvm::cl::OptionCategory CSCCategory("ct-code-style-checker options");
 
 static cl::opt<bool> MainTuOnly{
     "main-tu-only",
-    cl::desc("Only run on the main transletion unit "
+    cl::desc("Only run on the main translation unit "
              "(e.g. ignore included header files)"),
     cl::init(true), cl::cat(CSCCategory)};
 


### PR DESCRIPTION
Comments sections notes:

```
//    By default this plugin will only run on the main translation unit. Use
//    `-main-tu-only=true` to make it run on e.g. included header files too.
//
// USAGE:
//    Main TU only:
//      * clang -cc1 -load libCodeStyleChecker.dylib -plugin CSC `\`
//        input-file.cpp
//    All TUs (the main file and the #includ-ed header files)
//      * clang -cc1 -load libCodeStyleChecker.dylib -plugin CSC `\`
//        -main-tu-only=true input-file.cpp
```

There is a mismatch between true/false value and desired behavior.
Pull request is a proposal to change behavior and comment to make them consistent.