### PR TITLE
fix check against main translation unit location in CodeStyleChecker

### DIFF
--- a/include/CodeStyleChecker.h
+++ b/include/CodeStyleChecker.h
@@ -57,8 +57,12 @@ public:
       // Only visit declarations declared in in the input TU
       auto Decls = Ctx.getTranslationUnitDecl()->decls();
       for (auto &Decl : Decls) {
-        const auto &FileID = SM.getFileID(Decl->getLocation());
-        if (FileID != SM.getMainFileID())
+        // Ignore declarations out of the main translation unit.
+        //
+        // SourceManager::isInMainFile method takes into account locations
+        // expansion like macro expansion scenario and checks expansion
+        // location instead if spelling location if required.
+        if (!SM.isInMainFile(Decl->getLocation()))
           continue;
         Visitor.TraverseDecl(Decl);
       }

--- a/test/CodeStyleCheckerMacro.cpp
+++ b/test/CodeStyleCheckerMacro.cpp
@@ -1,6 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC -plugin-arg-CSC -main-tu-only=false %s 2>&1
-
-// TODO: Investigate why this is required: -plugin-arg-CSC -main-tu-only=false
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
 
 #define clang_tutor_class_ok(class_name) class ClangTutor##class_name
 #define clang_tutor_class_underscore(class_name) class Clang_TutorClass##class_name


### PR DESCRIPTION
Seems like expansion location ("presumed" location) should be used instead of spelling location for the check against main translation unit in CodeStyleChecker for macro expansion scenario.

I'm not 100% sure, could you please confirm.