### PR TITLE
fix unused for loop var checker for macro expansion scenario

### DIFF
--- a/include/CodeStyleChecker.h
+++ b/include/CodeStyleChecker.h
@@ -54,7 +54,7 @@ public:
     if (!MainTUOnly)
       Visitor.TraverseDecl(Ctx.getTranslationUnitDecl());
     else {
-      // Only visit declarations declared in in the input TU
+      // Only visit declarations declared in the input TU
       auto Decls = Ctx.getTranslationUnitDecl()->decls();
       for (auto &Decl : Decls) {
         // Ignore declarations out of the main translation unit.

--- a/include/UnusedForLoopVar.h
+++ b/include/UnusedForLoopVar.h
@@ -61,11 +61,10 @@ public:
   void HandleTranslationUnit(clang::ASTContext &Ctx) override {
     Matcher.matchAST(Ctx);
 
-    // Only visit declarations declared in in the input TU
+    // Only visit declarations declared in the input TU
     auto Decls = Ctx.getTranslationUnitDecl()->decls();
     for (auto &Decl : Decls) {
-      const auto &FileID = SM.getFileID(Decl->getLocation());
-      if (FileID != SM.getMainFileID())
+      if (!SM.isInMainFile(Decl->getLocation()))
         continue;
       UFLVVisitor.TraverseDecl(Decl);
     }

--- a/lib/UnusedForLoopVar.cpp
+++ b/lib/UnusedForLoopVar.cpp
@@ -55,7 +55,7 @@ void UnusedForLoopVarMatcher::runRegularForLoop(
 
   // Don't follow #include files
   if (RegularForLoop &&
-      !Ctx->getSourceManager().isWrittenInMainFile(RegularForLoop->getForLoc()))
+      !Ctx->getSourceManager().isInMainFile(RegularForLoop->getForLoc()))
     return;
 
   // Loop over all variables declared in the init statement of the loop
@@ -84,7 +84,7 @@ void UnusedForLoopVarMatcher::runRangeForLoop(
 
   // Don't follow #include files: range for-loop
   if (RangeForLoop &&
-      !Ctx->getSourceManager().isWrittenInMainFile(RangeForLoop->getForLoc()))
+      !Ctx->getSourceManager().isInMainFile(RangeForLoop->getForLoc()))
     return;
 
   // If LoopVar _is used_ there's nothing to report

--- a/test/UnusedForLoopVar_range_loop_macro.cpp
+++ b/test/UnusedForLoopVar_range_loop_macro.cpp
@@ -1,0 +1,16 @@
+// RUN: clang++ -Xclang -verify -Xclang -load -Xclang %shlibdir/libUnusedForLoopVar%shlibext -Xclang -plugin -Xclang UFLV -c %s 2>&1
+
+#define GENERATE_UNUSED_RANGE_FOR_LOOP_VAR(arr, inc) \
+  do {\
+    for (auto x : arr)\
+      ++inc;\
+  }\
+  while (0)
+
+int foo(int arg) {
+  int arr[3] = {1, 2, 3};
+  // expected-warning@+1 {{(AST Matcher) range for-loop variable not used}}
+  GENERATE_UNUSED_RANGE_FOR_LOOP_VAR(arr, arg);
+  return arg;
+}
+

--- a/test/UnusedForLoopVar_regular_loop_function_macro.cpp
+++ b/test/UnusedForLoopVar_regular_loop_function_macro.cpp
@@ -1,0 +1,12 @@
+// RUN: clang -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
+
+#define GENERATE_FUNCTION_WITH_UNUSED_REGULAR_FOR_LOOP_VAR(prefix) \
+  int func_##prefix(int arg) {\
+    for (int x = 0; x < 5; ++x)\
+      ++arg;\
+    return arg;\
+  }
+
+// expected-warning@+1 {{(Recursive AST Visitor) regular for-loop variable not used}}
+GENERATE_FUNCTION_WITH_UNUSED_REGULAR_FOR_LOOP_VAR(foo)
+

--- a/test/UnusedForLoopVar_regular_loop_macro.cpp
+++ b/test/UnusedForLoopVar_regular_loop_macro.cpp
@@ -1,0 +1,15 @@
+// RUN: clang -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
+
+#define GENERATE_UNUSED_REGULAR_FOR_LOOP_VAR(size, inc) \
+  do {\
+    for (int x = 0; x < size; ++x)\
+      ++inc;\
+  }\
+  while (0)
+
+int foo(int arg) {
+  // expected-warning@+1 {{(Recursive AST Visitor) regular for-loop variable not used}}
+  GENERATE_UNUSED_REGULAR_FOR_LOOP_VAR(3, arg);
+  return arg;
+}
+


### PR DESCRIPTION
Quite the same problem with macro expansion locations is applicable to UFLV plugin.

Proposal allows to find unused variables in a code like:

```c++
 24 #define GENERATE_UNUSED_RANGE_FOR_LOOP_VAR(arr, inc) \
 25     do {\
 26         for (auto x : arr)\
 27             ++inc;\
 28     }\
 29     while (0)
 30
 31 int foo4(int var_a) {
 32     int arr[3] = {1, 2, 3};
 33     GENERATE_UNUSED_RANGE_FOR_LOOP_VAR(arr, var_a);
 34     return var_a;
 35 }
 36
 37 #define GENERATE_UNUSED_REGULAR_FOR_LOOP_VAR(size, inc) \
 38     do {\
 39         for (int x = 0; x < size; ++x)\
 40             ++inc;\
 41     }\
 42     while (0)
 43
 44 int foo5(int var_a) {
 45     GENERATE_UNUSED_REGULAR_FOR_LOOP_VAR(3, var_a);
 46     return var_a;
 47 }
```

Report message is:

```c++
input_unusedforloopvar.cpp:33:5: warning: (AST Matcher) range for-loop variable not used
    GENERATE_UNUSED_RANGE_FOR_LOOP_VAR(arr, var_a);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
input_unusedforloopvar.cpp:26:19: note: expanded from macro 'GENERATE_UNUSED_RANGE_FOR_LOOP_VAR'
        for (auto x : arr)\
             ~~~~~^~
input_unusedforloopvar.cpp:45:5: warning: (Recursive AST Visitor) regular for-loop variable not used
    GENERATE_UNUSED_REGULAR_FOR_LOOP_VAR(3, var_a);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
input_unusedforloopvar.cpp:39:18: note: expanded from macro 'GENERATE_UNUSED_REGULAR_FOR_LOOP_VAR'
        for (int x = 0; x < size; ++x)\
             ~~~~^~~~
```