### PR TITLE
Fix DSO missing from command line error when llvm/clang build as shared libs

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -29,10 +29,22 @@ foreach( tool ${CLANG_TUTOR_TOOLS} )
       ${tool}
       ${${tool}_SOURCES}
       )
-
-    # Link with libclangTooling
+    
+    # Link with required llvm components   
+    set(LLVM_LINK_COMPONENTS
+      support
+      FrontendOpenMP
+      )
+    
+    # link with required clang components 
     target_link_libraries(
       ${tool}
+      clangAST
+      clangASTMatchers
+      clangBasic
+      clangFrontend
+      clangRewrite
+      clangSerialization
       clangTooling
     )
 


### PR DESCRIPTION
When we build LLVM/Clang as a shared library, we need to specify all shared libraries needed by clang-tutor' tools. Without that error like `undefined reference to symbol '_ZN5clang12ast_matchers8callExprE'
/usr/bin/ld: /home/xgupta/dev/llvm-project-11.0.0/build/lib/libclangASTMatchers.so.11: error adding symbols: DSO missing from command line` occured.