### PR TITLE
Support typical cmake find_package variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,12 @@ project(clang-tutor)
 # Set this to a valid Clang installation dir
 set(CT_LLVM_INSTALL_DIR "" CACHE PATH "LLVM installation directory")
 
+if (DEFINED LLVM_DIR)
+  set(CT_LLVM_INSTALL_DIR "${LLVM_DIR}/../..")
+elseif (DEFINED Clang_DIR)
+  set(CT_LLVM_INSTALL_DIR "${Clang_DIR}/../..")
+endif()
+
 # A bit of a sanity checking
 set(CT_LLVM_INCLUDE_DIR "${CT_LLVM_INSTALL_DIR}/include/llvm")
 if(NOT EXISTS "${CT_LLVM_INCLUDE_DIR}")


### PR DESCRIPTION
cmake lets you define `PACKAGENAME_DIR` to point to a directory
containing the cmake configuration files necessary to import a package.
The current method overrides and blocks this from working. Support the
typical cmake workflow by integrating it into the already existing
implementation.

This lets you invoke the build via

`cmake -DClang_DIR=${LLVM_INSTALL_DIR}/lib/cmake ..` as per usual.

See [the docs](https://cmake.org/cmake/help/latest/command/find_package.html) for reference.