### PR TITLE
added a cmake presets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,37 @@
+{
+  "version": 7,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 27,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "hello",
+      "displayName": "Hello World Config",
+      "description": "Hello World build using Ninja generator",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+         "CT_Clang_INSTALL_DIR": "/usr/lib/llvm-16"
+      },
+      "environment": {
+        "Clang_DIR": "/usr/lib/llvm-16",
+        "CLANG_TUTOR_DIR": "${sourceDir}"
+      },
+      "vendor": {
+        "example.com/ExampleIDE/1.0": {
+          "autoFormat": true
+        }
+      },
+      "debug": { "output": true }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "hello",
+      "configurePreset": "hello",
+      "targets": "HelloWorld"
+    }
+  ]
+}


### PR DESCRIPTION
Newer versions of `cmake` support `CMakePresets.json` which provide a convenient way of specifying platform and toolchain settings. 
This PR provides is a simple example which works with Ubuntu 20.04

I think it would be useful to update the documentation to indicate that llvm v16 is required and which packages are needed. 

https://apt.llvm.org/

Here is the `/etc/apt/sources.list.d/llvm.list` 
```text
deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main
```
And, here the signatures.
```text
sudo wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
```

Here are the packages I installed to get this to work.

```bash
sudo wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
sudo apt-get install clang-16 lldb-16 lld-16
sudo apt-get install libllvm-16-ocaml-dev libllvm16 llvm-16 llvm-16-dev llvm-16-doc llvm-16-examples llvm-16-runtime
sudo apt-get install clang-16 clang-tools-16 clang-16-doc libclang-common-16-dev libclang-16-dev libclang1-16 clang-format-16 python3-clang-16 clangd-16 clang-tidy-16
```
Then to configure and build.
```bash
cmake --preset hello
cmake --build --preset hello
```

I have not added a test to run the generated executable.