### PR TITLE
Make CodeStyleChecker to be used in a real compilation process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,21 @@ the warnings with correct source code information.
 `-fcolor-diagnostics` above instructs Clang to generate color output
 (unfortunately Markdown doesn't render the colors here).
 
+The **CodeStyleChecker** plugin could be used during the compilation process to 
+detect errors in the code, and get the output file, for example:
+```bash
+$Clang_DIR/bin/clang -fplugin=libCodeStyleChecker.dylib -o file.o -c file.cpp
+file.cpp:2:7: warning: Type and variable names should start with upper-case letter
+class clangTutor_BadName;
+      ^~~~~~~~~~~~~~~~~~~
+      ClangTutor_BadName
+file.cpp:2:17: warning: `_` in names is not allowed
+class clangTutor_BadName;
+      ~~~~~~~~~~^~~~~~~~~
+      clangTutorBadName
+2 warnings generated.
+```
+
 ### Run the plugin through `ct-code-style-checker`
 **ct-code-style-checker** is a standalone tool that will run the **CodeStyleChecker** plugin,
 but without the need of using `clang` and loading the plugin:

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ $Clang_DIR/bin/clang -cc1 -load <build_dir>/lib/libLACommenter.dylib -plugin LAC
 ```
 
 ### Run the plugin through `ct-la-commenter`
-**locommenter** is a standalone tool that will run the **LACommenter** plugin,
+**lacommenter** is a standalone tool that will run the **LACommenter** plugin,
 but without the need of using `clang` and loading the plugin:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -358,8 +358,17 @@ the warnings with correct source code information.
 `-fcolor-diagnostics` above instructs Clang to generate color output
 (unfortunately Markdown doesn't render the colors here).
 
-The **CodeStyleChecker** plugin could be used during the compilation process to 
-detect errors in the code, and get the output file, for example:
+According to [Clang Plugins](https://clang.llvm.org/docs/ClangPlugins.html#using-the-clang-command-line)
+> If the plugin class implements the `getActionType` method then the plugin is run automatically. 
+```c
+// Automatically run the plugin after the main AST action
+PluginASTAction::ActionType getActionType() override {
+  return AddAfterMainAction;
+}
+```
+
+The **CodeStyleChecker** plugin could be automatically load and be used during the normal compilation 
+process to detect errors in the code, and get the output file, for example:
 ```bash
 $Clang_DIR/bin/clang -fplugin=libCodeStyleChecker.dylib -o file.o -c file.cpp
 file.cpp:2:7: warning: Type and variable names should start with upper-case letter

--- a/lib/CodeStyleChecker.cpp
+++ b/lib/CodeStyleChecker.cpp
@@ -193,6 +193,10 @@ public:
     ros << "Help for CodeStyleChecker plugin goes here\n";
   }
 
+  PluginASTAction::ActionType getActionType() override {
+    return AddAfterMainAction;
+  }
+
 private:
   bool MainTuOnly = true;
 };

--- a/lib/CodeStyleChecker.cpp
+++ b/lib/CodeStyleChecker.cpp
@@ -194,7 +194,11 @@ public:
   }
 
   PluginASTAction::ActionType getActionType() override {
-    return AddAfterMainAction;
+#ifndef TARGET_CLANG_TOOL
+    return AddBeforeMainAction;
+#else
+    return CmdlineAfterMainAction;
+#endif
   }
 
 private:

--- a/test/CodeStyleCheckerAnonymous.cpp
+++ b/test/CodeStyleCheckerAnonymous.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // 1. Verify that anonymous unions are not flagged as invalid (no name ->
 // nothing to check). However, the member variables _are_ verified.

--- a/test/CodeStyleCheckerConversionOp.cpp
+++ b/test/CodeStyleCheckerConversionOp.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify  -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // Verify that conversion operators are not checked
 

--- a/test/CodeStyleCheckerFunction.cpp
+++ b/test/CodeStyleCheckerFunction.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // Verify that function names starting with upper case are reported as invalid
 

--- a/test/CodeStyleCheckerMacro.cpp
+++ b/test/CodeStyleCheckerMacro.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 #define clang_tutor_class_ok(class_name) class ClangTutor##class_name
 #define clang_tutor_class_underscore(class_name) class Clang_TutorClass##class_name

--- a/test/CodeStyleCheckerTypesAndVars.cpp
+++ b/test/CodeStyleCheckerTypesAndVars.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // Verify that type and variable names starting with lower case are reported as
 // invalid

--- a/test/CodeStyleCheckerUnderscore.cpp
+++ b/test/CodeStyleCheckerUnderscore.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // Verify that underscare in types, variables and function names are reported
 // as invalid

--- a/test/CodeStyleCheckerVector.cpp
+++ b/test/CodeStyleCheckerVector.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -c %s
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=true -c %s
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=false -c %s
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=true -c %s
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=false -c %s
 
 #include <vector>
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -40,4 +40,9 @@ foreach( tool ${CLANG_TUTOR_TOOLS} )
       ${tool}
       "clangTooling"
     )
+
+    # ct action type should be CmdlineAfterMainAction
+    if(${tool} STREQUAL "ct-code-style-checker")
+      target_compile_definitions(${tool} PRIVATE TARGET_CLANG_TOOL=1)
+    endif()
 endforeach()


### PR DESCRIPTION
Adding the getActionType method to allow the clang plugin to automatically load plugins during the compilation process.