### PR TITLE
feat: Support running Clang Tools in-process via getActionType

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,21 @@ the warnings with correct source code information.
 `-fcolor-diagnostics` above instructs Clang to generate color output
 (unfortunately Markdown doesn't render the colors here).
 
+The **CodeStyleChecker** plugin could be used during the compilation process to 
+detect errors in the code, and get the output file, for example:
+```bash
+$Clang_DIR/bin/clang -fplugin=libCodeStyleChecker.dylib -o file.o -c file.cpp
+file.cpp:2:7: warning: Type and variable names should start with upper-case letter
+class clangTutor_BadName;
+      ^~~~~~~~~~~~~~~~~~~
+      ClangTutor_BadName
+file.cpp:2:17: warning: `_` in names is not allowed
+class clangTutor_BadName;
+      ~~~~~~~~~~^~~~~~~~~
+      clangTutorBadName
+2 warnings generated.
+```
+
 ### Run the plugin through `ct-code-style-checker`
 **ct-code-style-checker** is a standalone tool that will run the **CodeStyleChecker** plugin,
 but without the need of using `clang` and loading the plugin:

--- a/README.md
+++ b/README.md
@@ -358,7 +358,9 @@ the warnings with correct source code information.
 `-fcolor-diagnostics` above instructs Clang to generate color output
 (unfortunately Markdown doesn't render the colors here).
 
-According to [Clang Plugins](https://clang.llvm.org/docs/ClangPlugins.html#using-the-clang-command-line)
+### Run the plugin and compile the input
+
+In the invocation from the previous section, Clang runs only one action - the plugin itself. This means that no output files are generated. In order to run a plugin action _and_ e.g. a compilation action, you need implement `getActionType` method (from [Clang Plugins](https://clang.llvm.org/docs/ClangPlugins.html#using-the-clang-command-line)):
 > If the plugin class implements the `getActionType` method then the plugin is run automatically. 
 ```c
 // Automatically run the plugin after the main AST action
@@ -367,7 +369,7 @@ PluginASTAction::ActionType getActionType() override {
 }
 ```
 
-The **CodeStyleChecker** plugin could be automatically load and be used during the normal compilation 
+The **CodeStyleChecker** plugin does implement `getActionType` and hence can be run automatically and used during the normal compilation 
 process to detect errors in the code, and get the output file, for example:
 ```bash
 $Clang_DIR/bin/clang -fplugin=libCodeStyleChecker.dylib -o file.o -c file.cpp

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ $Clang_DIR/bin/clang -cc1 -load <build_dir>/lib/libLACommenter.dylib -plugin LAC
 ```
 
 ### Run the plugin through `ct-la-commenter`
-**locommenter** is a standalone tool that will run the **LACommenter** plugin,
+**lacommenter** is a standalone tool that will run the **LACommenter** plugin,
 but without the need of using `clang` and loading the plugin:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -358,8 +358,17 @@ the warnings with correct source code information.
 `-fcolor-diagnostics` above instructs Clang to generate color output
 (unfortunately Markdown doesn't render the colors here).
 
-The **CodeStyleChecker** plugin could be used during the compilation process to 
-detect errors in the code, and get the output file, for example:
+According to [Clang Plugins](https://clang.llvm.org/docs/ClangPlugins.html#using-the-clang-command-line)
+> If the plugin class implements the `getActionType` method then the plugin is run automatically. 
+```c
+// Automatically run the plugin after the main AST action
+PluginASTAction::ActionType getActionType() override {
+  return AddAfterMainAction;
+}
+```
+
+The **CodeStyleChecker** plugin could be automatically load and be used during the normal compilation 
+process to detect errors in the code, and get the output file, for example:
 ```bash
 $Clang_DIR/bin/clang -fplugin=libCodeStyleChecker.dylib -o file.o -c file.cpp
 file.cpp:2:7: warning: Type and variable names should start with upper-case letter

--- a/lib/CodeStyleChecker.cpp
+++ b/lib/CodeStyleChecker.cpp
@@ -193,6 +193,10 @@ public:
     ros << "Help for CodeStyleChecker plugin goes here\n";
   }
 
+  PluginASTAction::ActionType getActionType() override {
+    return AddAfterMainAction;
+  }
+
 private:
   bool MainTuOnly = true;
 };

--- a/lib/CodeStyleChecker.cpp
+++ b/lib/CodeStyleChecker.cpp
@@ -194,7 +194,11 @@ public:
   }
 
   PluginASTAction::ActionType getActionType() override {
-    return AddAfterMainAction;
+#ifndef TARGET_CLANG_TOOL
+    return AddBeforeMainAction;
+#else
+    return CmdlineAfterMainAction;
+#endif
   }
 
 private:

--- a/test/CodeStyleCheckerAnonymous.cpp
+++ b/test/CodeStyleCheckerAnonymous.cpp
@@ -1,6 +1,12 @@
 // RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
-// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
-// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
+
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
+
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
 
 // 1. Verify that anonymous unions are not flagged as invalid (no name ->
 // nothing to check). However, the member variables _are_ verified.

--- a/test/CodeStyleCheckerAnonymous.cpp
+++ b/test/CodeStyleCheckerAnonymous.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // 1. Verify that anonymous unions are not flagged as invalid (no name ->
 // nothing to check). However, the member variables _are_ verified.

--- a/test/CodeStyleCheckerConversionOp.cpp
+++ b/test/CodeStyleCheckerConversionOp.cpp
@@ -1,13 +1,22 @@
 // RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
-// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
-// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
-// Verify that conversion operators are not checked
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
 
-// expected-no-diagnostics
-class SomeClass {
-public:
-  operator bool();
-  operator int();
-  operator char();
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
+
+// Verify that function names starting with upper case are reported as invalid
+
+// expected-warning@+1 {{Function names should start with lower-case letter}}
+void ClangTutorFuncBad();
+
+void clangTutorFuncOK();
+
+struct ClangTutorStruct {
+  // expected-warning@+1 {{Function names should start with lower-case letter}}
+  void ClangTutorMemberMethodBad();
+  void clangTutorMemberMethodOK();
 };

--- a/test/CodeStyleCheckerConversionOp.cpp
+++ b/test/CodeStyleCheckerConversionOp.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify  -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // Verify that conversion operators are not checked
 

--- a/test/CodeStyleCheckerFunction.cpp
+++ b/test/CodeStyleCheckerFunction.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // Verify that function names starting with upper case are reported as invalid
 

--- a/test/CodeStyleCheckerFunction.cpp
+++ b/test/CodeStyleCheckerFunction.cpp
@@ -1,6 +1,12 @@
 // RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
-// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
-// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
+
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
+
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
 
 // Verify that function names starting with upper case are reported as invalid
 

--- a/test/CodeStyleCheckerMacro.cpp
+++ b/test/CodeStyleCheckerMacro.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 #define clang_tutor_class_ok(class_name) class ClangTutor##class_name
 #define clang_tutor_class_underscore(class_name) class Clang_TutorClass##class_name

--- a/test/CodeStyleCheckerMacro.cpp
+++ b/test/CodeStyleCheckerMacro.cpp
@@ -1,6 +1,12 @@
 // RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
-// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
-// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
+
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
+
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
 
 #define clang_tutor_class_ok(class_name) class ClangTutor##class_name
 #define clang_tutor_class_underscore(class_name) class Clang_TutorClass##class_name

--- a/test/CodeStyleCheckerTypesAndVars.cpp
+++ b/test/CodeStyleCheckerTypesAndVars.cpp
@@ -1,6 +1,12 @@
 // RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
-// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
-// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
+
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
+
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
 
 // Verify that type and variable names starting with lower case are reported as
 // invalid

--- a/test/CodeStyleCheckerTypesAndVars.cpp
+++ b/test/CodeStyleCheckerTypesAndVars.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // Verify that type and variable names starting with lower case are reported as
 // invalid

--- a/test/CodeStyleCheckerUnderscore.cpp
+++ b/test/CodeStyleCheckerUnderscore.cpp
@@ -1,6 +1,12 @@
 // RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
-// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
-// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
+
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
+
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s -o %t.o
+// RUN: test -f %t.o
+// RUN: rm %t.o
 
 // Verify that underscare in types, variables and function names are reported
 // as invalid

--- a/test/CodeStyleCheckerUnderscore.cpp
+++ b/test/CodeStyleCheckerUnderscore.cpp
@@ -1,4 +1,6 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -add-plugin CSC %s 2>&1
+// RUN: clang -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s 2>&1
+// RUN: clang -fplugin=%shlibdir/libCodeStyleChecker%shlibext -c %s 2>&1
 
 // Verify that underscare in types, variables and function names are reported
 // as invalid

--- a/test/CodeStyleCheckerVector.cpp
+++ b/test/CodeStyleCheckerVector.cpp
@@ -1,6 +1,15 @@
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=true -c %s
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=false -c %s
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s -o %t1.o 2>&1
+// RUN: test -f %t1.o
+// RUN: rm %t1.o
+
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=true -c %s -o %t2.o 2>&1
+// RUN: test -f %t2.o
+// RUN: rm %t2.o
+
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=false -c %s -o %t3.o 2>&1
+// RUN: test -f %t3.o
+// RUN: rm %t3.o
+
 
 #include <vector>
 

--- a/test/CodeStyleCheckerVector.cpp
+++ b/test/CodeStyleCheckerVector.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -c %s
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=true -c %s
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=false -c %s
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -c %s
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=true -c %s
+// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -add-plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=false -c %s
 
 #include <vector>
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -40,4 +40,9 @@ foreach( tool ${CLANG_TUTOR_TOOLS} )
       ${tool}
       "clangTooling"
     )
+
+    # ct action type should be CmdlineAfterMainAction
+    if(${tool} STREQUAL "ct-code-style-checker")
+      target_compile_definitions(${tool} PRIVATE TARGET_CLANG_TOOL=1)
+    endif()
 endforeach()


### PR DESCRIPTION

**Related Issue:**
Issue #33; PR #34

**Motivation**

When performing static analysis on large-scale C++ projects, a common requirement is to inject analysis tools into the standard compilation pipeline without interrupting it (i.e., to still produce an executable after the analysis). As discussed in #33, the current implementation makes it difficult to run the analysis and complete the full compilation to generate the final binary simultaneously.

**Solution**

After researching the LLVM/Clang plugin architecture, I found that we can override the virtual method `getActionType()` in `PluginASTAction` to modify the plugin's default behavior.

By returning `ActionType::AddBeforeMainAction`, our custom `ASTAction` is executed **before** the compiler's main action (e.g., codegen). This allows the analysis tool to be seamlessly integrated as a standard part of the compilation process, resolving the issue described above.

**History & Fixes**

* A previous attempt to introduce this feature was made in PR #34.
* At that time, the PR was stalled because I was unable to fix the test cases, due to a lack of familiarity with the `llvm-lit` testing framework (and being occupied with my graduation ).
* I have now fixed all relevant test cases, and they are passing both locally and in CI.

I'm happy to be contributing to this great tutor again!