### PR TITLE
Optimized the CMake build process to reduce its dependency on environment variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,61 +2,24 @@ cmake_minimum_required(VERSION 3.20)
 project(clang-tutor)
 
 #===============================================================================
-# 0. GET CLANG INSTALLATION DIR
+# 1. FIND CLANG/LLVM INSTALLATION
 #===============================================================================
-# In clang-tutor, `CT_Clang_INSTALL_DIR` is the key CMake variable - it points
-# to a Clang installation directory. For the sake of completeness,
-# <PackageName>_DIR (i.e. `Clang_DIR`) and <PackageName>_ROOT (i.e.
-# `Clang_ROOT`) are also supported. Visit CMake documentation for more details:
-#   https://cmake.org/cmake/help/latest/command/find_package.html
-# Use only _one_ of these variables.
+# Uses CMake's `find_package` to locate a Clang/LLVM installation.
+# To specify a custom installation path, run CMake with:
+#
+#   cmake -D CMAKE_PREFIX_PATH=/path/to/your/llvm/install ..
+#   (or)
+#   cmake -D LLVM_DIR=/path/to/your/llvm/install ..
+#
+# `find_package` will then automatically find the necessary configuration files.
 
-if(DEFINED Clang_ROOT)
-  set(CT_CLANG_PACKAGE_DIR "${Clang_ROOT}/../../..")
-elseif(DEFINED Clang_DIR)
-  set(CT_CLANG_PACKAGE_DIR "${Clang_DIR}/../../..")
-endif()
-mark_as_advanced(CT_CLANG_PACKAGE_DIR)
+find_package(Clang 19.1 REQUIRED CONFIG)
 
-# Set this to a valid Clang installation directory. This is most likely where
-# LLVM is installed on your system.
-set(CT_Clang_INSTALL_DIR "${CT_CLANG_PACKAGE_DIR}" CACHE PATH
-  "Clang installation directory")
+# The `find_package` command with a version number (e.g., 19) makes the
+# manual version check below redundant. It will fail automatically if a
+# compatible version isn't found.
 
-#===============================================================================
-# 1. VERIFY CLANG INSTALLATION DIR
-#===============================================================================
-set(CT_LLVM_INCLUDE_DIR "${CT_Clang_INSTALL_DIR}/include/llvm")
-if(NOT EXISTS "${CT_LLVM_INCLUDE_DIR}")
-message(FATAL_ERROR
-  " CT_Clang_INSTALL_DIR (${CT_LLVM_INCLUDE_DIR}) is invalid.")
-endif()
-
-set(CT_LLVM_CMAKE_FILE
-  "${CT_Clang_INSTALL_DIR}/lib/cmake/clang/ClangConfig.cmake")
-if(NOT EXISTS "${CT_LLVM_CMAKE_FILE}")
-message(FATAL_ERROR
-  " CT_LLVM_CMAKE_FILE (${CT_LLVM_CMAKE_FILE}) is invalid.")
-endif()
-
-#===============================================================================
-# 2. LOAD CLANG CONFIGURATION
-#    Extracted from:
-#    http://llvm.org/docs/CMake.html#embedding-llvm-in-your-project
-#===============================================================================
-list(APPEND CMAKE_PREFIX_PATH "${CT_Clang_INSTALL_DIR}/lib/cmake/clang/")
-
-find_package(Clang REQUIRED CONFIG)
-
-# Sanity check. As Clang does not expose e.g. `CLANG_VERSION_MAJOR` through
-# AddClang.cmake, we have to use LLVM_VERSION_MAJOR instead.
-# TODO: Revisit when next version is released.
-if("${LLVM_VERSION_MAJOR}" VERSION_LESS 19)
-  message(FATAL_ERROR "Found LLVM ${LLVM_VERSION_MAJOR}, but need LLVM 19 or above")
-endif()
-
-message(STATUS "Found Clang ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using ClangConfig.cmake in: ${CT_Clang_INSTALL_DIR}")
+message(STATUS "Found Clang/LLVM ${LLVM_PACKAGE_VERSION}")
 
 message("CLANG STATUS:
   Includes (clang)    ${CLANG_INCLUDE_DIRS}
@@ -64,10 +27,10 @@ message("CLANG STATUS:
 )
 
 # Set the LLVM and Clang header and library paths
-include_directories(SYSTEM "${LLVM_INCLUDE_DIRS};${CLANG_INCLUDE_DIRS}")
+include_directories(SYSTEM "${LLVM_INCLUDE_DIRS}" "${CLANG_INCLUDE_DIRS}")
 
 #===============================================================================
-# 3. CLANG-TUTOR BUILD CONFIGURATION
+# 2. CLANG-TUTOR BUILD CONFIGURATION
 #===============================================================================
 # Use the same C++ standard as LLVM does
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
@@ -102,7 +65,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
 
 #===============================================================================
-# 4. ADD SUB-TARGETS
+# 3. ADD SUB-TARGETS
 # Doing this at the end so that all definitions and link/include paths are
 # available for the sub-projects.
 #===============================================================================

--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ You can build and run **HelloWorld** like this:
 
 ```bash
 # Build the plugin
-export Clang_DIR=<installation/dir/of/clang/19>
+export LLVM_DIR=<installation/dir/of/clang/19>  # (Optional) 
 export CLANG_TUTOR_DIR=<source/dir/clang/tutor>
 mkdir build
 cd build
-cmake -DCT_Clang_INSTALL_DIR=$Clang_DIR $CLANG_TUTOR_DIR/HelloWorld/
+cmake -DLLVM_DIR=${LLVM_DIR} $CLANG_TUTOR_DIR/HelloWorld/
+# or just `cmake $CLANG_TUTOR_DIR/HelloWorld/`, for CMake find_package() can automatically find LLVM_DIR
 make
 # Run the plugin
-$Clang_DIR/bin/clang -cc1 -load ./libHelloWorld.{so|dylib} -plugin hello-world $CLANG_TUTOR_DIR/test/HelloWorld-basic.cpp
+${LLVM_DIR}/bin/clang -cc1 -load ./libHelloWorld.{so|dylib} -plugin hello-world $CLANG_TUTOR_DIR/test/HelloWorld-basic.cpp
 ```
 
 You should see the following output:
@@ -99,7 +100,7 @@ When running a Clang plugin on a C++ file that includes headers from STL, it is
 easier to run it with `clang++` (rather than `clang -cc1`) like this:
 
 ```bash
-$Clang_DIR/bin/clang++ -c -Xclang -load -Xclang libHelloWorld.dylib -Xclang -plugin -Xclang hello-world file.cpp
+${LLVM_DIR}/bin/clang++ -c -Xclang -load -Xclang libHelloWorld.dylib -Xclang -plugin -Xclang hello-world file.cpp
 ```
 
 This way you can be confident that all the necessary include paths (required to
@@ -277,7 +278,7 @@ You can test **LACommenter** on the example presented above. Assuming that it
 was saved in `input_file.c`, you can add comments to it as follows:
 
 ```bash
-$Clang_DIR/bin/clang -cc1 -load <build_dir>/lib/libLACommenter.dylib -plugin LAC input_file.cpp
+${LLVM_DIR}/bin/clang -cc1 -load <build_dir>/lib/libLACommenter.dylib -plugin LAC input_file.cpp
 ```
 
 ### Run the plugin through `ct-la-commenter`
@@ -338,7 +339,7 @@ The name of the class doesn't follow LLVM's coding guide and
 **CodeStyleChecker** indeed captures that:
 
 ```bash
-$Clang_DIR/bin/clang -cc1 -fcolor-diagnostics -load libCodeStyleChecker.dylib -plugin CSC file.cpp
+${LLVM_DIR}/bin/clang -cc1 -fcolor-diagnostics -load libCodeStyleChecker.dylib -plugin CSC file.cpp
 file.cpp:2:7: warning: Type and variable names should start with upper-case letter
 class clangTutor_BadName;
       ^~~~~~~~~~~~~~~~~~~
@@ -403,7 +404,7 @@ int foo(int a, int b) {
 You can run the plugin like this:
 
 ```bash
-$Clang_DIR/bin/clang -cc1 -load <build_dir>/lib/libObfuscator.dylib -plugin Obfuscator input.cpp
+${LLVM_DIR}/bin/clang -cc1 -load <build_dir>/lib/libObfuscator.dylib -plugin Obfuscator input.cpp
 ```
 
 You should see the following output on your screen.
@@ -498,7 +499,7 @@ examples (e.g.
 
 ### Run the plugin
 ```bash
-$Clang_DIR/bin/clang -cc1 -fcolor-diagnostics -load <build_dir>/lib/libUnusedForLoopVar.dylib -plugin UFLV input.cpp
+${LLVM_DIR}/bin/clang -cc1 -fcolor-diagnostics -load <build_dir>/lib/libUnusedForLoopVar.dylib -plugin UFLV input.cpp
 ```
 
 ## CodeRefactor
@@ -559,7 +560,7 @@ powerful in this respect.
 plugin is  _a bit_ cumbersome and probably best demonstrated with an example:
 
 ```bash
-$Clang_DIR/bin/clang -cc1 -load <build_dir>/lib/libCodeRefactor.dylib -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name -plugin-arg-CodeRefactor Base  -plugin-arg-CodeRefactor -old-name -plugin-arg-CodeRefactor foo  -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor bar file.cpp
+${LLVM_DIR}/bin/clang -cc1 -load <build_dir>/lib/libCodeRefactor.dylib -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name -plugin-arg-CodeRefactor Base  -plugin-arg-CodeRefactor -old-name -plugin-arg-CodeRefactor foo  -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor bar file.cpp
 ```
 
 It is much easier when you the plugin through a stand-alone tool like

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,11 @@
+
+get_target_property(CLANG_EXECUTABLE clang LOCATION)
+get_target_property(CLANGXX_EXECUTABLE clang LOCATION)
+get_target_property(LLVM_FILECHECK_EXECUTABLE FileCheck LOCATION)
+message(STATUS "[lit] Found clang at ${CLANG_EXECUTABLE}")
+message(STATUS "[lit] Found clang++ at ${CLANGXX_EXECUTABLE}")
+message(STATUS "[lit] Found FileCheck at ${LLVM_FILECHECK_EXECUTABLE}")
+
 set(CT_TEST_SHLIBEXT "${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
 set(CT_TEST_SITE_CFG_INPUT "${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in")

--- a/test/CodeRefactor_Class.cpp
+++ b/test/CodeRefactor_Class.cpp
@@ -1,7 +1,7 @@
-// RUN: clang -cc1 -load %shlibdir/libCodeRefactor%shlibext -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name \
+// RUN: %clang_cc -cc1 -load %shlibdir/libCodeRefactor%shlibext -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name \
 // RUN: -plugin-arg-CodeRefactor Base  -plugin-arg-CodeRefactor -old-name -plugin-arg-CodeRefactor run \
-// RUN: -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor walk %s 2>&1 | FileCheck %s --match-full-lines
-// RUN:  ../bin/ct-code-refactor --class-name=Base --new-name=walk --old-name=run %s -- | FileCheck %s --match-full-lines
+// RUN: -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor walk %s 2>&1 | %FileCheck %s --match-full-lines
+// RUN:  ../bin/ct-code-refactor --class-name=Base --new-name=walk --old-name=run %s -- | %FileCheck %s --match-full-lines
 
 // Verify that the method `run` is renamed as `walk` (in both Base and Derived)
 

--- a/test/CodeRefactor_Other.cpp
+++ b/test/CodeRefactor_Other.cpp
@@ -1,7 +1,7 @@
-// RUN: clang -cc1 -load %shlibdir/libCodeRefactor%shlibext -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name \
+// RUN: %clang_cc -cc1 -load %shlibdir/libCodeRefactor%shlibext -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name \
 // RUN: -plugin-arg-CodeRefactor Base  -plugin-arg-CodeRefactor -old-name -plugin-arg-CodeRefactor run \
-// RUN: -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor walk %s 2>&1 | FileCheck %s --match-full-lines
-// RUN:  ../bin/ct-code-refactor --class-name=Base --new-name=walk --old-name=run %s -- | FileCheck %s --match-full-lines
+// RUN: -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor walk %s 2>&1 | %FileCheck %s --match-full-lines
+// RUN:  ../bin/ct-code-refactor --class-name=Base --new-name=walk --old-name=run %s -- | %FileCheck %s --match-full-lines
 
 // Verify that Base::Run() or base::run() are *not* renamed as {B|b}ase::Walk()
 // (because there's no Base::Run())

--- a/test/CodeRefactor_Struct.cpp
+++ b/test/CodeRefactor_Struct.cpp
@@ -1,7 +1,7 @@
-// RUN: clang -cc1 -load %shlibdir/libCodeRefactor%shlibext -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name \
+// RUN: %clang_cc -cc1 -load %shlibdir/libCodeRefactor%shlibext -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name \
 // RUN: -plugin-arg-CodeRefactor Base  -plugin-arg-CodeRefactor -old-name -plugin-arg-CodeRefactor run \
-// RUN: -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor walk %s 2>&1 | FileCheck %s --match-full-lines
-// RUN:  ../bin/ct-code-refactor --class-name=Base --new-name=walk --old-name=run %s -- | FileCheck %s --match-full-lines
+// RUN: -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor walk %s 2>&1 | %FileCheck %s --match-full-lines
+// RUN:  ../bin/ct-code-refactor --class-name=Base --new-name=walk --old-name=run %s -- | %FileCheck %s --match-full-lines
 
 // Verify that the method `run` is renamed as `walk` (in both Base and Derived)
 

--- a/test/CodeRefactor_derived_only.cpp
+++ b/test/CodeRefactor_derived_only.cpp
@@ -1,7 +1,7 @@
-// RUN: clang -cc1 -load %shlibdir/libCodeRefactor%shlibext -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name \
+// RUN: %clang_cc -cc1 -load %shlibdir/libCodeRefactor%shlibext -plugin CodeRefactor -plugin-arg-CodeRefactor -class-name \
 // RUN: -plugin-arg-CodeRefactor Derived  -plugin-arg-CodeRefactor -old-name -plugin-arg-CodeRefactor run \
-// RUN: -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor walk %s 2>&1 | FileCheck %s --match-full-lines
-// RUN:  ../bin/ct-code-refactor --class-name=Derived --new-name=walk --old-name=run %s -- | FileCheck %s --match-full-lines
+// RUN: -plugin-arg-CodeRefactor -new-name -plugin-arg-CodeRefactor walk %s 2>&1 | %FileCheck %s --match-full-lines
+// RUN:  ../bin/ct-code-refactor --class-name=Derived --new-name=walk --old-name=run %s -- | %FileCheck %s --match-full-lines
 
 // Verify that Derived::run() is renamed as Derived::walk() (i.e. only the
 // derived class is refactored).

--- a/test/CodeStyleCheckerAnonymous.cpp
+++ b/test/CodeStyleCheckerAnonymous.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
 
 // 1. Verify that anonymous unions are not flagged as invalid (no name ->
 // nothing to check). However, the member variables _are_ verified.

--- a/test/CodeStyleCheckerConversionOp.cpp
+++ b/test/CodeStyleCheckerConversionOp.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify  -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: %clang_cc -cc1 -verify  -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
 
 // Verify that conversion operators are not checked
 

--- a/test/CodeStyleCheckerFunction.cpp
+++ b/test/CodeStyleCheckerFunction.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
 
 // Verify that function names starting with upper case are reported as invalid
 

--- a/test/CodeStyleCheckerMacro.cpp
+++ b/test/CodeStyleCheckerMacro.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
 
 #define clang_tutor_class_ok(class_name) class ClangTutor##class_name
 #define clang_tutor_class_underscore(class_name) class Clang_TutorClass##class_name

--- a/test/CodeStyleCheckerTypesAndVars.cpp
+++ b/test/CodeStyleCheckerTypesAndVars.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
 
 // Verify that type and variable names starting with lower case are reported as
 // invalid

--- a/test/CodeStyleCheckerUnderscore.cpp
+++ b/test/CodeStyleCheckerUnderscore.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libCodeStyleChecker%shlibext -plugin CSC %s 2>&1
 
 // Verify that underscare in types, variables and function names are reported
 // as invalid

--- a/test/CodeStyleCheckerVector.cpp
+++ b/test/CodeStyleCheckerVector.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -c %s
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=true -c %s
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=false -c %s
+// RUN: %clang_cxx -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -c %s
+// RUN: %clang_cxx -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=true -c %s
+// RUN: %clang_cxx -Xclang -load -Xclang %shlibdir/libCodeStyleChecker%shlibext -Xclang -plugin -Xclang CSC -Xclang -plugin-arg-CSC -Xclang -main-tu-only=false -c %s
 
 #include <vector>
 

--- a/test/HelloWorld-basic.cpp
+++ b/test/HelloWorld-basic.cpp
@@ -13,5 +13,5 @@ union Bez {
   float l;
 };
 
-// CHECK: (clang-tutor) file: {{.*}}/clang-tutor/test/HelloWorld-basic.cpp
+// CHECK: (clang-tutor) file: {{.*}}/test/HelloWorld-basic.cpp
 // CHECK-NEXT: (clang-tutor)  count: 3

--- a/test/HelloWorld-basic.cpp
+++ b/test/HelloWorld-basic.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -load %shlibdir/libHelloWorld%shlibext -plugin hello-world %s 2>&1 | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libHelloWorld%shlibext -plugin hello-world %s 2>&1 | %FileCheck %s
 
 class Foo {
   int i;

--- a/test/HelloWorld-macro.cpp
+++ b/test/HelloWorld-macro.cpp
@@ -8,5 +8,5 @@ clang_tutor_class(Foo) {
 clang_tutor_class(Bar) {
 };
 
-// CHECK: (clang-tutor) file: {{.*}}/clang-tutor/test/HelloWorld-macro.cpp
+// CHECK: (clang-tutor) file: {{.*}}/test/HelloWorld-macro.cpp
 // CHECK-NEXT: (clang-tutor)  count: 2

--- a/test/HelloWorld-macro.cpp
+++ b/test/HelloWorld-macro.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -load %shlibdir/libHelloWorld%shlibext -plugin hello-world %s 2>&1 | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libHelloWorld%shlibext -plugin hello-world %s 2>&1 | %FileCheck %s
 
 #define clang_tutor_class(class_name) class ClangTutor##class_name
 

--- a/test/HelloWorld-no-records.cpp
+++ b/test/HelloWorld-no-records.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -load %shlibdir/libHelloWorld%shlibext -plugin hello-world %s 2>&1 | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libHelloWorld%shlibext -plugin hello-world %s 2>&1 | %FileCheck %s
 
 int i;
 

--- a/test/HelloWorld-vector.cpp
+++ b/test/HelloWorld-vector.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -Xclang -load -Xclang %shlibdir/libHelloWorld%shlibext -Xclang -plugin -Xclang hello-world -c %s 2>&1 | FileCheck %s
+// RUN: %clang_cxx -Xclang -load -Xclang %shlibdir/libHelloWorld%shlibext -Xclang -plugin -Xclang hello-world -c %s 2>&1 | %FileCheck %s
 
 #include <vector>
 

--- a/test/LACBool.cpp
+++ b/test/LACBool.cpp
@@ -1,5 +1,5 @@
-// RUN: clang -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | FileCheck %s
-// RUN: ../bin/ct-la-commenter %s 2>&1 -- | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | %FileCheck %s
+// RUN: ../bin/ct-la-commenter %s 2>&1 -- | %FileCheck %s
 
 // CHECK-LABEL: bar()
 // CHECK-NEXT: foo(/*some_arg=*/true);

--- a/test/LACChar.cpp
+++ b/test/LACChar.cpp
@@ -1,5 +1,5 @@
-// RUN: clang -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | FileCheck %s
-// RUN: ../bin/ct-la-commenter %s 2>&1 -- | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | %FileCheck %s
+// RUN: ../bin/ct-la-commenter %s 2>&1 -- | %FileCheck %s
 
 // CHECK-LABEL: bar()
 // CHECK-NEXT: foo(/*some_arg=*/'1');

--- a/test/LACFloat.cpp
+++ b/test/LACFloat.cpp
@@ -1,5 +1,5 @@
-// RUN: clang -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | FileCheck %s
-// RUN: ../bin/ct-la-commenter %s 2>&1 -- | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | %FileCheck %s
+// RUN: ../bin/ct-la-commenter %s 2>&1 -- | %FileCheck %s
 
 // CHECK-LABEL: bar()
 // CHECK-NEXT: foo(/*some_arg=*/1.0);

--- a/test/LACInt.cpp
+++ b/test/LACInt.cpp
@@ -1,5 +1,5 @@
-// RUN: clang -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | FileCheck %s
-// RUN: ../bin/ct-la-commenter %s 2>&1 -- | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | %FileCheck %s
+// RUN: ../bin/ct-la-commenter %s 2>&1 -- | %FileCheck %s
 
 // CHECK-LABEL: bar()
 // CHECK-NEXT: foo(/*some_arg=*/1);

--- a/test/LACLong.cpp
+++ b/test/LACLong.cpp
@@ -1,5 +1,5 @@
-// RUN: clang -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | FileCheck %s
-// RUN: ../bin/ct-la-commenter %s 2>&1 -- | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | %FileCheck %s
+// RUN: ../bin/ct-la-commenter %s 2>&1 -- | %FileCheck %s
 
 // CHECK-LABEL: bar()
 // CHECK-NEXT: foo(/*a=*/1, /*b=*/1.0, /*c=*/'1', /*d=*/"one", /*e=*/true);

--- a/test/LACString.cpp
+++ b/test/LACString.cpp
@@ -1,5 +1,5 @@
-// RUN: clang -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | FileCheck %s
-// RUN: ../bin/ct-la-commenter %s 2>&1 -- | FileCheck %s
+// RUN: %clang_cc -cc1 -load %shlibdir/libLACommenter%shlibext -plugin LAC %s 2>&1 | %FileCheck %s
+// RUN: ../bin/ct-la-commenter %s 2>&1 -- | %FileCheck %s
 
 // CHECK-LABEL: bar()
 // CHECK-NEXT: foo(/*some_arg=*/"one");

--- a/test/MBA_add_int.cpp
+++ b/test/MBA_add_int.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -load %shlibdir/libObfuscator%shlibext -plugin Obfuscator %s 2>&1 | FileCheck %s --match-full-lines
+// RUN: %clang_cc -cc1 -load %shlibdir/libObfuscator%shlibext -plugin Obfuscator %s 2>&1 | %FileCheck %s --match-full-lines
 // TODO We need --match-full-lines to make sure that FileCheck doesn't match
 // against the CHECK lines. Normally, the comments in the input file can be
 // stripped by the preprocessor. However, if I add `-E -P` to strip the

--- a/test/MBA_float_add.cpp
+++ b/test/MBA_float_add.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -load %shlibdir/libObfuscator%shlibext -add-plugin Obfuscator %s 2>&1 | FileCheck --allow-empty %s --match-full-lines
+// RUN: %clang_cc -cc1 -load %shlibdir/libObfuscator%shlibext -add-plugin Obfuscator %s 2>&1 | %FileCheck --allow-empty %s --match-full-lines
 // TODO We need --match-full-lines to make sure that FileCheck doesn't match
 // against the CHECK lines. Normally, the comments in the input file can be
 // stripped by the preprocessor. However, if I add `-E -P` to strip the

--- a/test/MBA_float_sub.cpp
+++ b/test/MBA_float_sub.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -load %shlibdir/libObfuscator%shlibext -add-plugin Obfuscator %s 2>&1 | FileCheck --allow-empty %s --match-full-lines
+// RUN: %clang_cc -cc1 -load %shlibdir/libObfuscator%shlibext -add-plugin Obfuscator %s 2>&1 | %FileCheck --allow-empty %s --match-full-lines
 // TODO We need --match-full-lines to make sure that FileCheck doesn't match
 // against the CHECK lines. Normally, the comments in the input file can be
 // stripped by the preprocessor. However, if I add `-E -P` to strip the

--- a/test/MBA_sub_int.cpp
+++ b/test/MBA_sub_int.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -load %shlibdir/libObfuscator%shlibext -plugin Obfuscator %s 2>&1 | FileCheck %s --match-full-lines
+// RUN: %clang_cc -cc1 -load %shlibdir/libObfuscator%shlibext -plugin Obfuscator %s 2>&1 | %FileCheck %s --match-full-lines
 // TODO We need --match-full-lines to make sure that FileCheck doesn't match
 // against the CHECK lines. Normally, the comments in the input file can be
 // stripped by the preprocessor. However, if I add `-E -P` to strip the

--- a/test/UnusedForLoopVar_nested.cpp
+++ b/test/UnusedForLoopVar_nested.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
 
 int foo() {
   int a = 10;

--- a/test/UnusedForLoopVar_range_loop.cpp
+++ b/test/UnusedForLoopVar_range_loop.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -Xclang -verify -Xclang -load -Xclang %shlibdir/libUnusedForLoopVar%shlibext -Xclang -plugin -Xclang UFLV -c %s 2>&1
+// RUN: %clang_cxx -Xclang -verify -Xclang -load -Xclang %shlibdir/libUnusedForLoopVar%shlibext -Xclang -plugin -Xclang UFLV -c %s 2>&1
 
 #include <vector>
 

--- a/test/UnusedForLoopVar_range_loop_ignored.cpp
+++ b/test/UnusedForLoopVar_range_loop_ignored.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -Xclang -verify -Xclang -load -Xclang %shlibdir/libUnusedForLoopVar%shlibext -Xclang -plugin -Xclang UFLV -c %s 2>&1
+// RUN: %clang_cxx -Xclang -verify -Xclang -load -Xclang %shlibdir/libUnusedForLoopVar%shlibext -Xclang -plugin -Xclang UFLV -c %s 2>&1
 
 // Unused for loop variables are are not reported by the plugin, because their
 // name match: [U|u][N|n][U|u][S|s][E|e][D|d]

--- a/test/UnusedForLoopVar_range_loop_macro.cpp
+++ b/test/UnusedForLoopVar_range_loop_macro.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -Xclang -verify -Xclang -load -Xclang %shlibdir/libUnusedForLoopVar%shlibext -Xclang -plugin -Xclang UFLV -c %s 2>&1
+// RUN: %clang_cxx -Xclang -verify -Xclang -load -Xclang %shlibdir/libUnusedForLoopVar%shlibext -Xclang -plugin -Xclang UFLV -c %s 2>&1
 
 #define GENERATE_UNUSED_RANGE_FOR_LOOP_VAR(arr, inc) \
   do {\

--- a/test/UnusedForLoopVar_regular_loop.cpp
+++ b/test/UnusedForLoopVar_regular_loop.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
 
 int foo() {
   int a = 10;

--- a/test/UnusedForLoopVar_regular_loop_function_macro.cpp
+++ b/test/UnusedForLoopVar_regular_loop_function_macro.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
 
 #define GENERATE_FUNCTION_WITH_UNUSED_REGULAR_FOR_LOOP_VAR(prefix) \
   int func_##prefix(int arg) {\

--- a/test/UnusedForLoopVar_regular_loop_ignored.cpp
+++ b/test/UnusedForLoopVar_regular_loop_ignored.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
 
 // Unused for loop variables are are not reported by the plugin, because their
 // name match: [U|u][N|n][U|u][S|s][E|e][D|d]

--- a/test/UnusedForLoopVar_regular_loop_macro.cpp
+++ b/test/UnusedForLoopVar_regular_loop_macro.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
 
 #define GENERATE_UNUSED_REGULAR_FOR_LOOP_VAR(size, inc) \
   do {\

--- a/test/UnusedForLoopVar_regular_nested_loop.cpp
+++ b/test/UnusedForLoopVar_regular_nested_loop.cpp
@@ -1,4 +1,4 @@
-// RUN: clang -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
+// RUN: %clang_cc -cc1 -verify -load %shlibdir/libUnusedForLoopVar%shlibext -plugin UFLV %s 2>&1
 
 int foo() {
   int a = 10;

--- a/test/ct-code-style-checker-basic.cpp
+++ b/test/ct-code-style-checker-basic.cpp
@@ -1,5 +1,5 @@
-// RUN:  ../bin/ct-code-style-checker %s 2>&1 -- | FileCheck -implicit-check-not warning: %s
-// RUN:  ../bin/ct-code-style-checker -main-tu-only=true %s 2>&1 -- | FileCheck -implicit-check-not warning: %s
+// RUN:  ../bin/ct-code-style-checker %s 2>&1 -- | %FileCheck -implicit-check-not warning: %s
+// RUN:  ../bin/ct-code-style-checker -main-tu-only=true %s 2>&1 -- | %FileCheck -implicit-check-not warning: %s
 
 // This is a rather simplified test for CodeStyleChecker that focuses on the
 // standalone wrapper tool: ct-code-style-checker. 

--- a/test/ct-code-style-checker-include-files.cpp
+++ b/test/ct-code-style-checker-include-files.cpp
@@ -1,5 +1,5 @@
-// RUN:  ../bin/ct-code-style-checker -main-tu-only=false %s 2>&1 -- | FileCheck -implicit-check-not warning: -check-prefixes=WITH_INCLUDED_FILES %s
-// RUN:  ../bin/ct-code-style-checker -main-tu-only=true %s 2>&1 -- | FileCheck -implicit-check-not warning: -allow-empty %s
+// RUN:  ../bin/ct-code-style-checker -main-tu-only=false %s 2>&1 -- | %FileCheck -implicit-check-not warning: -check-prefixes=WITH_INCLUDED_FILES %s
+// RUN:  ../bin/ct-code-style-checker -main-tu-only=true %s 2>&1 -- | %FileCheck -implicit-check-not warning: -allow-empty %s
 
 #include "Inputs/ct-code-style-checker-header-file.h"
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -34,9 +34,10 @@ config.test_source_root = os.path.dirname(__file__)
 config.excludes = ['Inputs']
 
 # The list of tools required for testing - prepend them with the path specified
-# during configuration (i.e. LT_LLVM_TOOLS_DIR/bin)
-tools = ["FileCheck", "clang", "clang++"]
-llvm_config.add_tool_substitutions(tools, config.llvm_tools_dir)
+# during configuration
+config.substitutions.append(('%clang', config.clang_path))
+config.substitutions.append(('%clangxx', config.clangxx_path))
+config.substitutions.append(('%FileCheck', config.filecheck_path))
 
 # The LIT variable to hold the file extension for shared libraries (this is
 # platform dependent)

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -35,8 +35,8 @@ config.excludes = ['Inputs']
 
 # The list of tools required for testing - prepend them with the path specified
 # during configuration
-config.substitutions.append(('%clang', config.clang_path))
-config.substitutions.append(('%clangxx', config.clangxx_path))
+config.substitutions.append(('%clang_cc', config.clang_path))
+config.substitutions.append(('%clang_cxx', config.clangxx_path))
 config.substitutions.append(('%FileCheck', config.filecheck_path))
 
 # The LIT variable to hold the file extension for shared libraries (this is

--- a/test/lit.site.cfg.py.in
+++ b/test/lit.site.cfg.py.in
@@ -1,6 +1,9 @@
 import sys
 
-config.llvm_tools_dir = "@CT_Clang_INSTALL_DIR@/bin"
+config.clang_path = r"@CLANG_EXECUTABLE@"
+config.clangxx_path = r"@CLANGXX_EXECUTABLE@"
+config.filecheck_path = r"@LLVM_FILECHECK_EXECUTABLE@"
+
 config.llvm_shlib_ext = "@CT_TEST_SHLIBEXT@"
 config.llvm_shlib_dir = "@CMAKE_LIBRARY_OUTPUT_DIRECTORY@"
 


### PR DESCRIPTION
As mentioned in #37, the current project's CMake relies on relative paths for Clang_DIR during builds, which is quite fragile. I modified the CMake build process and implemented dynamic lookup using placeholders for test suites during lit testing.